### PR TITLE
fix tf.reverse at backward for tensorflow v1.x

### DIFF
--- a/HiddenMarkovModel.py
+++ b/HiddenMarkovModel.py
@@ -189,7 +189,7 @@ class HiddenMarkovModel(object):
                 # Update backward matrix
                 self.backward = tf.scatter_update(self.backward, step+1, self.scale[self.N-2-step] * backward_prob)
         
-        self.backward = tf.assign(self.backward, tf.reverse(self.backward, [True, False]))
+        self.backward = tf.assign(self.backward, tf.reverse(self.backward, [0]))
 
         
     def _posterior(self):
@@ -277,7 +277,7 @@ class HiddenMarkovModel(object):
             # forward belief propagation
             self._forward(obs_prob_list_for)
 
-        obs_prob_seq_rev = tf.reverse(obs_prob_seq, [True, False])
+        obs_prob_seq_rev = tf.reverse(obs_prob_seq, [0])
         obs_prob_list_back = tf.split(obs_prob_seq_rev, self.N, 0)
 
         with tf.name_scope('backward_belief_propagation'):


### PR DESCRIPTION
@365andreas and I have found an issue while running the Baum-Welch algorithm for HMM with TensorFlow 1.15.  The tf.reverse() for backward function was called in a wrong way (since it referred to an older version of TensorFlow [(see here)](https://github.com/tensorflow/tensorflow/releases?after=v1.1.0-rc2)) leading to wrong results. We have changed its call.